### PR TITLE
Add tests for every examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,27 @@ pnpm run example function
 pnpm run example function_streaming
 ```
 
+## 🧪 Testing
+
+### Important Notes
+
+- Server must be running (`pnpm dev`) on `http://localhost:3000`
+- `HF_TOKEN` environment variable set with your Hugging Face token
+- Tests use real inference providers and will incur costs
+- Tests are not run in CI due to billing requirements
+
+### Running Tests
+
+```bash
+# Run all tests
+pnpm test
+
+# Run specific test patterns
+pnpm test --grep "streaming"
+pnpm test --grep "function"
+pnpm test --grep "structured"
+```
+
 ### Interactive Demo UI
 
 Experience the API through our interactive web interface, adapted from the [openai-responses-starter-app](https://github.com/openai/openai-responses-starter-app).

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,7 @@ export default [
 				node: "readonly",
 				console: "readonly",
 				process: "readonly",
+				fetch: "readonly",
 			},
 		},
 		plugins: {
@@ -39,6 +40,26 @@ export default [
 			"@typescript-eslint/no-empty-interfaces": "off",
 			// For doc purposes, prefer interfaces
 			"@typescript-eslint/consistent-type-definitions": ["error", "interface"],
+		},
+	},
+	{
+		files: ["**/*.test.js", "**/*.test.ts"],
+		languageOptions: {
+			globals: {
+				describe: "readonly",
+				it: "readonly",
+				before: "readonly",
+				beforeEach: "readonly",
+				after: "readonly",
+				afterEach: "readonly",
+				context: "readonly",
+				suite: "readonly",
+				test: "readonly",
+				specify: "readonly",
+				xdescribe: "readonly",
+				xit: "readonly",
+				xtest: "readonly",
+			},
 		},
 	},
 	prettierConfig,

--- a/examples/streaming.js
+++ b/examples/streaming.js
@@ -6,7 +6,7 @@ const stream = await openai.responses.create({
 	input: [
 		{
 			role: "user",
-			content: "Say 'double bubble bath' ten times fast.",
+			content: "What's the capital of France?",
 		},
 	],
 	stream: true,

--- a/examples/structured_output.js
+++ b/examples/structured_output.js
@@ -4,27 +4,18 @@ import { z } from "zod";
 
 const openai = new OpenAI({ baseURL: "http://localhost:3000/v1", apiKey: process.env.HF_TOKEN });
 
-const Step = z.object({
-	explanation: z.string(),
-	output: z.string(),
-});
-
-const MathReasoning = z.object({
-	steps: z.array(Step),
-	final_answer: z.string(),
+const CalendarEvent = z.object({
+	name: z.string(),
+	date: z.string(),
+	participants: z.array(z.string()),
 });
 
 const response = await openai.responses.parse({
 	model: "novita@meta-llama/Meta-Llama-3-70B-Instruct",
-	input: [
-		{
-			role: "system",
-			content: "You are a helpful math tutor. Guide the user through the solution step by step.",
-		},
-		{ role: "user", content: "how can I solve 8x + 7 = -23" },
-	],
+	instructions: "Extract the event information.",
+	input: "Alice and Bob are going to a science fair on Friday.",
 	text: {
-		format: zodTextFormat(MathReasoning, "math_reasoning"),
+		format: zodTextFormat(CalendarEvent, "calendar_event"),
 	},
 });
 

--- a/examples/structured_output_streaming.js
+++ b/examples/structured_output_streaming.js
@@ -9,30 +9,18 @@ const CalendarEvent = z.object({
 });
 
 const openai = new OpenAI({ baseURL: "http://localhost:3000/v1", apiKey: process.env.HF_TOKEN });
-const stream = openai.responses
-	.stream({
-		model: "nebius@Qwen/Qwen2.5-VL-72B-Instruct",
-		instructions: "Extract the event information.",
-		input: "Alice and Bob are going to a science fair on Friday.",
-		text: {
-			format: zodTextFormat(CalendarEvent, "calendar_event"),
-		},
-	})
-	.on("response.refusal.delta", (event) => {
-		process.stdout.write(event.delta);
-	})
-	.on("response.output_text.delta", (event) => {
-		process.stdout.write(event.delta);
-	})
-	.on("response.output_text.done", () => {
-		process.stdout.write("\n");
-	})
-	.on("response.error", (event) => {
-		console.error(event.error);
-	})
-	.on("response.completed", (event) => {
-		console.log(event.response);
-	});
+const stream = openai.responses.stream({
+	model: "nebius@Qwen/Qwen2.5-VL-72B-Instruct",
+	instructions: "Extract the event information.",
+	input: "Alice and Bob are going to a science fair on Friday.",
+	text: {
+		format: zodTextFormat(CalendarEvent, "calendar_event"),
+	},
+});
+
+for await (const event of stream) {
+	console.log(event);
+}
 
 const result = await stream.finalResponse();
 console.log(result.output_parsed);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
 		"demo:lint": "cd demo && npm run lint",
 		"demo:format": "cd demo && npm run format",
 		"demo:start": "cd demo && npm run start",
-		"deploy:spaces": "./push_to_space.sh"
+		"deploy:spaces": "./push_to_space.sh",
+		"test": "mocha --timeout 20000 \"tests/**/*.test.js\""
 	},
 	"files": [
 		"src",
@@ -72,6 +73,7 @@
 		"eslint": "^9.30.1",
 		"eslint-config-prettier": "^10.1.5",
 		"eslint-plugin-prettier": "^5.5.1",
+		"mocha": "^11.7.1",
 		"prettier": "^3.6.2",
 		"tsup": "^8.5.0",
 		"tsx": "^4.20.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.1
         version: 5.5.1(eslint-config-prettier@10.1.5(eslint@9.30.1))(eslint@9.30.1)(prettier@3.6.2)
+      mocha:
+        specifier: ^11.7.1
+        version: 11.7.1
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -592,6 +595,9 @@ packages:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
+  browser-stdout@1.3.1:
+    resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
+
   bundle-require@5.1.0:
     resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -618,6 +624,10 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  camelcase@6.3.0:
+    resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
+    engines: {node: '>=10'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -625,6 +635,10 @@ packages:
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -695,6 +709,10 @@ packages:
       supports-color:
         optional: true
 
+  decamelize@4.0.0:
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==}
+    engines: {node: '>=10'}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -705,6 +723,10 @@ packages:
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+
+  diff@7.0.0:
+    resolution: {integrity: sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==}
+    engines: {node: '>=0.3.1'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -746,6 +768,10 @@ packages:
     resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
 
   escape-html@1.0.3:
     resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
@@ -896,6 +922,10 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
+  flat@5.0.2:
+    resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
+    hasBin: true
+
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
 
@@ -922,6 +952,10 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
 
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
@@ -968,6 +1002,10 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
@@ -1020,8 +1058,16 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -1073,6 +1119,10 @@ packages:
 
   lodash.sortby@4.7.0:
     resolution: {integrity: sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -1145,6 +1195,11 @@ packages:
 
   mlly@1.7.4:
     resolution: {integrity: sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw==}
+
+  mocha@11.7.1:
+    resolution: {integrity: sha512-5EK+Cty6KheMS/YLPPMJC64g5V61gIR25KsRItHw6x4hEKT6Njp1n9LOlH4gpevuwMVS66SXaBBpg+RWZkza4A==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    hasBin: true
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -1319,6 +1374,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  randombytes@2.1.0:
+    resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
@@ -1334,6 +1392,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1380,6 +1442,9 @@ packages:
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
+
+  serialize-javascript@6.0.2:
+    resolution: {integrity: sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==}
 
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
@@ -1460,6 +1525,10 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  supports-color@8.1.1:
+    resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
+    engines: {node: '>=10'}
 
   synckit@0.11.8:
     resolution: {integrity: sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==}
@@ -1580,6 +1649,9 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  workerpool@9.3.3:
+    resolution: {integrity: sha512-slxCaKbYjEdFT/o2rH9xS1hf4uRDch1w7Uo+apxhZ+sf/1d9e0ZVkn42kPNGP2dgjIx6YFvSevj0zHvbWe2jdw==}
+
   wrap-ansi@7.0.0:
     resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
     engines: {node: '>=10'}
@@ -1603,10 +1675,26 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yaml@2.8.0:
     resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
     engines: {node: '>= 14.6'}
     hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs-unparser@2.0.0:
+    resolution: {integrity: sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==}
+    engines: {node: '>=10'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -1707,7 +1795,7 @@ snapshots:
   '@eslint/config-array@0.21.0':
     dependencies:
       '@eslint/object-schema': 2.1.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -1725,7 +1813,7 @@ snapshots:
   '@eslint/eslintrc@3.3.1':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -1957,7 +2045,7 @@ snapshots:
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.30.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -1967,7 +2055,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -1985,7 +2073,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/utils': 8.35.1(eslint@9.30.1)(typescript@5.8.3)
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       eslint: 9.30.1
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
@@ -2000,7 +2088,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -2088,7 +2176,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       http-errors: 2.0.0
       iconv-lite: 0.6.3
       on-finished: 2.4.1
@@ -2111,6 +2199,8 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
+  browser-stdout@1.3.1: {}
+
   bundle-require@5.1.0(esbuild@0.25.5):
     dependencies:
       esbuild: 0.25.5
@@ -2132,6 +2222,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  camelcase@6.3.0: {}
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -2140,6 +2232,12 @@ snapshots:
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   color-convert@2.0.1:
     dependencies:
@@ -2186,15 +2284,21 @@ snapshots:
     dependencies:
       ms: 2.0.0
 
-  debug@4.4.1:
+  debug@4.4.1(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
+
+  decamelize@4.0.0: {}
 
   deep-is@0.1.4: {}
 
   depd@2.0.0: {}
 
   destroy@1.2.0: {}
+
+  diff@7.0.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -2250,6 +2354,8 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.5
       '@esbuild/win32-x64': 0.25.5
 
+  escalade@3.2.0: {}
+
   escape-html@1.0.3: {}
 
   escape-string-regexp@4.0.0: {}
@@ -2294,7 +2400,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -2390,7 +2496,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.2.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -2460,7 +2566,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -2485,6 +2591,8 @@ snapshots:
       flatted: 3.3.3
       keyv: 4.5.4
 
+  flat@5.0.2: {}
+
   flatted@3.3.3: {}
 
   foreground-child@3.3.1:
@@ -2502,6 +2610,8 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -2556,6 +2666,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  he@1.2.0: {}
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -2597,7 +2709,11 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-plain-obj@2.1.0: {}
+
   is-promise@4.0.0: {}
+
+  is-unicode-supported@0.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -2641,6 +2757,11 @@ snapshots:
   lodash.merge@4.6.2: {}
 
   lodash.sortby@4.7.0: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
 
   lru-cache@10.4.3: {}
 
@@ -2697,6 +2818,29 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.1
+
+  mocha@11.7.1:
+    dependencies:
+      browser-stdout: 1.3.1
+      chokidar: 4.0.3
+      debug: 4.4.1(supports-color@8.1.1)
+      diff: 7.0.0
+      escape-string-regexp: 4.0.0
+      find-up: 5.0.0
+      glob: 10.4.5
+      he: 1.2.0
+      js-yaml: 4.1.0
+      log-symbols: 4.1.0
+      minimatch: 9.0.5
+      ms: 2.1.3
+      picocolors: 1.1.1
+      serialize-javascript: 6.0.2
+      strip-json-comments: 3.1.1
+      supports-color: 8.1.1
+      workerpool: 9.3.3
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
+      yargs-unparser: 2.0.0
 
   ms@2.0.0: {}
 
@@ -2830,6 +2974,10 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  randombytes@2.1.0:
+    dependencies:
+      safe-buffer: 5.2.1
+
   range-parser@1.2.1: {}
 
   raw-body@2.5.2:
@@ -2847,6 +2995,8 @@ snapshots:
       unpipe: 1.0.0
 
   readdirp@4.1.2: {}
+
+  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -2884,7 +3034,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -2922,7 +3072,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -2935,6 +3085,10 @@ snapshots:
       statuses: 2.0.1
     transitivePeerDependencies:
       - supports-color
+
+  serialize-javascript@6.0.2:
+    dependencies:
+      randombytes: 2.1.0
 
   serve-static@1.16.2:
     dependencies:
@@ -3037,6 +3191,10 @@ snapshots:
     dependencies:
       has-flag: 4.0.0
 
+  supports-color@8.1.1:
+    dependencies:
+      has-flag: 4.0.0
+
   synckit@0.11.8:
     dependencies:
       '@pkgr/core': 0.2.7
@@ -3080,7 +3238,7 @@ snapshots:
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
-      debug: 4.4.1
+      debug: 4.4.1(supports-color@8.1.1)
       esbuild: 0.25.5
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
@@ -3154,6 +3312,8 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  workerpool@9.3.3: {}
+
   wrap-ansi@7.0.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -3171,8 +3331,29 @@ snapshots:
   ws@8.18.3:
     optional: true
 
+  y18n@5.0.8: {}
+
   yaml@2.8.0:
     optional: true
+
+  yargs-parser@21.1.1: {}
+
+  yargs-unparser@2.0.0:
+    dependencies:
+      camelcase: 6.3.0
+      decamelize: 4.0.0
+      flat: 5.0.2
+      is-plain-obj: 2.1.0
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/tests/responses.test.js
+++ b/tests/responses.test.js
@@ -1,0 +1,724 @@
+import OpenAI from "openai";
+import { strict as assert } from "assert";
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
+
+describe("responses.js", function () {
+	let openai;
+
+	// Check if server is running before all tests
+	before(async function () {
+		try {
+			const response = await fetch("http://localhost:3000/");
+			if (response.status !== 200) {
+				throw new Error(`Server returned status ${response.status}`);
+			}
+		} catch (error) {
+			console.error("❌ Server is not running. Please start the server with 'pnpm dev' before running the tests.");
+			throw error;
+		}
+
+		openai = new OpenAI({
+			baseURL: "http://localhost:3000/v1",
+			apiKey: process.env.HF_TOKEN,
+		});
+	});
+
+	it("text input, text output", async function () {
+		const response = await openai.responses.create({
+			model: "Qwen/Qwen2.5-VL-7B-Instruct",
+			instructions: "You are a helpful assistant.",
+			input: "Tell me a three sentence bedtime story about a unicorn.",
+		});
+		assert.equal(typeof response.output_text, "string");
+		assert.ok(response.output_text.length > 0);
+	});
+
+	it("text+image input, text output", async function () {
+		const response = await openai.responses.create({
+			model: "Qwen/Qwen2.5-VL-7B-Instruct",
+			input: [
+				{
+					role: "user",
+					content: [
+						{ type: "input_text", text: "what is in this image?" },
+						{
+							type: "input_image",
+							image_url:
+								"https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg",
+						},
+					],
+				},
+			],
+		});
+		assert.equal(typeof response.output_text, "string");
+		assert.ok(response.output_text.length > 0);
+	});
+
+	it("multi-turn conversation, text output", async function () {
+		const response = await openai.responses.create({
+			model: "Qwen/Qwen2.5-VL-7B-Instruct",
+			input: [
+				{
+					role: "developer",
+					content: "Talk like a pirate.",
+				},
+				{
+					role: "user",
+					content: "Are semicolons optional in JavaScript?",
+				},
+			],
+		});
+		assert.equal(typeof response.output_text, "string");
+		assert.ok(response.output_text.length > 0);
+	});
+
+	it("function calling", async function () {
+		const tools = [
+			{
+				type: "function",
+				name: "get_current_weather",
+				description: "Get the current weather in a given location",
+				parameters: {
+					type: "object",
+					properties: {
+						location: {
+							type: "string",
+							description: "The city and state, e.g. San Francisco, CA",
+						},
+						unit: { type: "string", enum: ["celsius", "fahrenheit"] },
+					},
+					required: ["location", "unit"],
+				},
+			},
+		];
+
+		const response = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			tools: tools,
+			input: "What is the weather like in Boston today?",
+			tool_choice: "auto",
+		});
+
+		assert.ok(Array.isArray(response.output));
+		assert.equal(response.output.length, 1);
+		assert.equal(response.output[0].type, "function_call");
+		assert.equal(response.output[0].status, "completed");
+		assert.equal(response.output[0].name, "get_current_weather");
+	});
+
+	it("structured output", async function () {
+		const CalendarEvent = z.object({
+			name: z.string(),
+			date: z.string(),
+			participants: z.array(z.string()),
+		});
+		const response = await openai.responses.parse({
+			model: "novita@meta-llama/Meta-Llama-3-70B-Instruct",
+			instructions: "Extract the event information.",
+			input: "Alice and Bob are going to a science fair on Friday.",
+			text: {
+				format: zodTextFormat(CalendarEvent, "calendar_event"),
+			},
+		});
+
+		assert.ok(response.output_parsed);
+		assert.equal(typeof response.output_parsed, "object");
+		assert.equal(typeof response.output_parsed.name, "string");
+		assert.equal(typeof response.output_parsed.date, "string");
+		assert.ok(Array.isArray(response.output_parsed.participants));
+	});
+
+	it("streaming response", async function () {
+		const stream = await openai.responses.create({
+			model: "hyperbolic@Qwen/Qwen2.5-VL-7B-Instruct",
+			input: [
+				{
+					role: "user",
+					content: "What's the capital of France?",
+				},
+			],
+			stream: true,
+		});
+
+		const events = [];
+		let sequenceNumber = 0;
+
+		for await (const event of stream) {
+			// Check sequence number is ascending starting from 0
+			assert.equal(event.sequence_number, sequenceNumber);
+			sequenceNumber++;
+
+			events.push(event);
+		}
+
+		// Check the exact sequence order
+		const expectedSequence = [
+			"response.created",
+			"response.in_progress",
+			"response.output_item.added",
+			"response.content_part.added",
+		];
+
+		// Check the first 4 events match the expected sequence
+		expectedSequence.forEach((expectedType, index) => {
+			assert.equal(events[index].type, expectedType, `Event ${index} should be ${expectedType}`);
+		});
+
+		// Check that all middle events are delta events
+		const middleEvents = events.slice(4, -4);
+		middleEvents.forEach((event, index) => {
+			assert.equal(
+				event.type,
+				"response.output_text.delta",
+				`Middle event ${index} should be response.output_text.delta`
+			);
+		});
+
+		// Check the final 4 events
+		const finalEvents = [
+			"response.output_text.done",
+			"response.content_part.done",
+			"response.output_item.done",
+			"response.completed",
+		];
+
+		const actualFinalEvents = events.slice(-4);
+		finalEvents.forEach((expectedType, index) => {
+			assert.equal(actualFinalEvents[index].type, expectedType, `Final event ${index} should be ${expectedType}`);
+		});
+
+		// Check specific event validations
+		const createdEvents = events.filter((e) => e.type === "response.created");
+		assert.equal(createdEvents.length, 1);
+		assert.ok(createdEvents[0].response);
+
+		const inProgressEvents = events.filter((e) => e.type === "response.in_progress");
+		assert.equal(inProgressEvents.length, 1);
+		assert.ok(inProgressEvents[0].response);
+
+		const outputItemAddedEvents = events.filter((e) => e.type === "response.output_item.added");
+		assert.equal(outputItemAddedEvents.length, 1);
+		assert.ok(outputItemAddedEvents[0].item);
+		assert.equal(outputItemAddedEvents[0].item.type, "message");
+
+		const contentPartAddedEvents = events.filter((e) => e.type === "response.content_part.added");
+		assert.equal(contentPartAddedEvents.length, 1);
+		assert.ok(contentPartAddedEvents[0].part);
+		assert.equal(contentPartAddedEvents[0].part.type, "output_text");
+
+		// Check all delta events
+		const deltaEvents = events.filter((e) => e.type === "response.output_text.delta");
+		assert.ok(deltaEvents.length > 0);
+		deltaEvents.forEach((deltaEvent) => {
+			assert.equal(typeof deltaEvent.delta, "string");
+		});
+
+		const outputTextDoneEvents = events.filter((e) => e.type === "response.output_text.done");
+		assert.equal(outputTextDoneEvents.length, 1);
+		assert.ok(outputTextDoneEvents[0].text);
+		assert.ok(outputTextDoneEvents[0].text.length > 0);
+
+		const contentPartDoneEvents = events.filter((e) => e.type === "response.content_part.done");
+		assert.equal(contentPartDoneEvents.length, 1);
+		assert.equal(contentPartDoneEvents[0].part.type, "output_text");
+		assert.ok(contentPartDoneEvents[0].part.text);
+
+		const outputItemDoneEvents = events.filter((e) => e.type === "response.output_item.done");
+		assert.equal(outputItemDoneEvents.length, 1);
+		assert.equal(outputItemDoneEvents[0].item.type, "message");
+
+		const completedEvents = events.filter((e) => e.type === "response.completed");
+		assert.equal(completedEvents.length, 1);
+		assert.ok(completedEvents[0].response);
+		assert.ok(completedEvents[0].response.usage.input_tokens > 0);
+		assert.ok(completedEvents[0].response.usage.output_tokens > 0);
+		assert.ok(completedEvents[0].response.usage.total_tokens > 0);
+		assert.equal(completedEvents[0].response.output[0].content[0].type, "output_text");
+		assert.ok(completedEvents[0].response.output[0].content[0].text);
+	});
+
+	it("function streaming", async function () {
+		const tools = [
+			{
+				type: "function",
+				name: "get_weather",
+				description: "Get current temperature for provided coordinates in celsius.",
+				parameters: {
+					type: "object",
+					properties: {
+						latitude: { type: "number" },
+						longitude: { type: "number" },
+					},
+					required: ["latitude", "longitude"],
+					additionalProperties: false,
+				},
+				strict: true,
+			},
+		];
+
+		const stream = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			input: [{ role: "user", content: "What's the weather like in Paris today?" }],
+			tools,
+			stream: true,
+		});
+
+		const events = [];
+		let sequenceNumber = 0;
+
+		for await (const event of stream) {
+			// Check sequence number is ascending starting from 0
+			assert.equal(event.sequence_number, sequenceNumber);
+			sequenceNumber++;
+
+			events.push(event);
+		}
+
+		// Check the exact sequence order for function streaming
+		const expectedSequence = [
+			"response.created",
+			"response.in_progress",
+			"response.output_item.added",
+			"response.function_call_arguments.delta",
+			"response.function_call_arguments.done",
+			"response.output_item.done",
+			"response.completed",
+		];
+
+		// Check the events match the expected sequence
+		expectedSequence.forEach((expectedType, index) => {
+			assert.equal(events[index].type, expectedType, `Event ${index} should be ${expectedType}`);
+		});
+
+		// Check specific event validations
+		const createdEvents = events.filter((e) => e.type === "response.created");
+		assert.equal(createdEvents.length, 1);
+		assert.ok(createdEvents[0].response);
+
+		const inProgressEvents = events.filter((e) => e.type === "response.in_progress");
+		assert.equal(inProgressEvents.length, 1);
+		assert.ok(inProgressEvents[0].response);
+
+		const outputItemAddedEvents = events.filter((e) => e.type === "response.output_item.added");
+		assert.equal(outputItemAddedEvents.length, 1);
+		assert.ok(outputItemAddedEvents[0].item);
+		assert.equal(outputItemAddedEvents[0].item.type, "function_call");
+		assert.equal(outputItemAddedEvents[0].item.name, "get_weather");
+		assert.ok(outputItemAddedEvents[0].item.id);
+		assert.ok(outputItemAddedEvents[0].item.call_id);
+
+		const functionCallArgumentsDeltaEvents = events.filter((e) => e.type === "response.function_call_arguments.delta");
+		assert.equal(functionCallArgumentsDeltaEvents.length, 1);
+		assert.ok(functionCallArgumentsDeltaEvents[0].delta);
+		assert.equal(typeof functionCallArgumentsDeltaEvents[0].delta, "string");
+		assert.ok(functionCallArgumentsDeltaEvents[0].item_id);
+
+		const functionCallArgumentsDoneEvents = events.filter((e) => e.type === "response.function_call_arguments.done");
+		assert.equal(functionCallArgumentsDoneEvents.length, 1);
+		assert.ok(functionCallArgumentsDoneEvents[0].arguments);
+		assert.equal(typeof functionCallArgumentsDoneEvents[0].arguments, "string");
+		assert.ok(functionCallArgumentsDoneEvents[0].item_id);
+		const argumentsJson = JSON.parse(functionCallArgumentsDoneEvents[0].arguments);
+		assert.ok(typeof argumentsJson.latitude === "number");
+		assert.ok(typeof argumentsJson.longitude === "number");
+
+		const outputItemDoneEvents = events.filter((e) => e.type === "response.output_item.done");
+		assert.equal(outputItemDoneEvents.length, 1);
+		assert.equal(outputItemDoneEvents[0].item.type, "function_call");
+		assert.equal(outputItemDoneEvents[0].item.name, "get_weather");
+		assert.equal(outputItemDoneEvents[0].item.status, "completed");
+		assert.ok(outputItemDoneEvents[0].item.arguments);
+
+		const completedEvents = events.filter((e) => e.type === "response.completed");
+		assert.equal(completedEvents.length, 1);
+		assert.ok(completedEvents[0].response);
+		assert.ok(completedEvents[0].response.usage.input_tokens > 0);
+		assert.ok(completedEvents[0].response.usage.output_tokens > 0);
+		assert.ok(completedEvents[0].response.usage.total_tokens > 0);
+		assert.equal(completedEvents[0].response.output[0].type, "function_call");
+		assert.equal(completedEvents[0].response.output[0].name, "get_weather");
+		assert.equal(completedEvents[0].response.output[0].status, "completed");
+	});
+
+	it("structured output streaming", async function () {
+		const CalendarEvent = z.object({
+			name: z.string(),
+			date: z.string(),
+			participants: z.array(z.string()),
+		});
+
+		const stream = openai.responses.stream({
+			model: "nebius@Qwen/Qwen2.5-VL-72B-Instruct",
+			instructions: "Extract the event information.",
+			input: "Alice and Bob are going to a science fair on Friday.",
+			text: {
+				format: zodTextFormat(CalendarEvent, "calendar_event"),
+			},
+		});
+
+		const events = [];
+		let sequenceNumber = 0;
+
+		for await (const event of stream) {
+			// Check sequence number is ascending starting from 0
+			assert.equal(event.sequence_number, sequenceNumber);
+			sequenceNumber++;
+
+			events.push(event);
+		}
+
+		// Check the exact sequence order for structured output streaming
+		const expectedSequence = [
+			"response.created",
+			"response.in_progress",
+			"response.output_item.added",
+			"response.content_part.added",
+		];
+
+		// Check the first 4 events match the expected sequence
+		expectedSequence.forEach((expectedType, index) => {
+			assert.equal(events[index].type, expectedType, `Event ${index} should be ${expectedType}`);
+		});
+
+		// Check that all middle events are delta events
+		const middleEvents = events.slice(4, -4);
+		middleEvents.forEach((event, index) => {
+			assert.equal(
+				event.type,
+				"response.output_text.delta",
+				`Middle event ${index} should be response.output_text.delta`
+			);
+		});
+
+		// Check the final 4 events
+		const finalEvents = [
+			"response.output_text.done",
+			"response.content_part.done",
+			"response.output_item.done",
+			"response.completed",
+		];
+
+		const actualFinalEvents = events.slice(-4);
+		finalEvents.forEach((expectedType, index) => {
+			assert.equal(actualFinalEvents[index].type, expectedType, `Final event ${index} should be ${expectedType}`);
+		});
+
+		// Check specific event validations
+		const createdEvents = events.filter((e) => e.type === "response.created");
+		assert.equal(createdEvents.length, 1);
+		assert.ok(createdEvents[0].response);
+
+		const inProgressEvents = events.filter((e) => e.type === "response.in_progress");
+		assert.equal(inProgressEvents.length, 1);
+		assert.ok(inProgressEvents[0].response);
+
+		const outputItemAddedEvents = events.filter((e) => e.type === "response.output_item.added");
+		assert.equal(outputItemAddedEvents.length, 1);
+		assert.ok(outputItemAddedEvents[0].item);
+		assert.equal(outputItemAddedEvents[0].item.type, "message");
+
+		const contentPartAddedEvents = events.filter((e) => e.type === "response.content_part.added");
+		assert.equal(contentPartAddedEvents.length, 1);
+		assert.ok(contentPartAddedEvents[0].part);
+		assert.equal(contentPartAddedEvents[0].part.type, "output_text");
+
+		// Check all delta events
+		const deltaEvents = events.filter((e) => e.type === "response.output_text.delta");
+		assert.ok(deltaEvents.length > 0);
+		deltaEvents.forEach((deltaEvent) => {
+			assert.equal(typeof deltaEvent.delta, "string");
+		});
+
+		const outputTextDoneEvents = events.filter((e) => e.type === "response.output_text.done");
+		assert.equal(outputTextDoneEvents.length, 1);
+		assert.ok(outputTextDoneEvents[0].text);
+		assert.ok(outputTextDoneEvents[0].text.length > 0);
+
+		const contentPartDoneEvents = events.filter((e) => e.type === "response.content_part.done");
+		assert.equal(contentPartDoneEvents.length, 1);
+		assert.equal(contentPartDoneEvents[0].part.type, "output_text");
+		assert.ok(contentPartDoneEvents[0].part.text);
+
+		const outputItemDoneEvents = events.filter((e) => e.type === "response.output_item.done");
+		assert.equal(outputItemDoneEvents.length, 1);
+		assert.equal(outputItemDoneEvents[0].item.type, "message");
+
+		const completedEvents = events.filter((e) => e.type === "response.completed");
+		assert.equal(completedEvents.length, 1);
+		assert.ok(completedEvents[0].response);
+		assert.equal(completedEvents[0].response.output[0].content[0].type, "output_text");
+		assert.ok(completedEvents[0].response.output[0].content[0].text);
+
+		// Test finalResponse() method
+		const result = await stream.finalResponse();
+		assert.ok(result.output_parsed);
+		assert.equal(typeof result.output_parsed, "object");
+		assert.equal(typeof result.output_parsed.name, "string");
+		assert.equal(typeof result.output_parsed.date, "string");
+		assert.ok(Array.isArray(result.output_parsed.participants));
+		assert.equal(result.output_parsed.name, "Science Fair");
+		assert.equal(result.output_parsed.date, "Friday");
+		assert.deepEqual(result.output_parsed.participants, ["Alice", "Bob"]);
+	});
+
+	it("MCP approved tool call", async function () {
+		const response = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			input: [
+				{
+					type: "message",
+					role: "user",
+					content: "how does tiktoken work?",
+				},
+				{
+					type: "mcp_approval_request",
+					id: "mcp_approval_request_123",
+					server_label: "gitmcp",
+					name: "fetch_tiktoken_documentation",
+					arguments: "{}",
+				},
+				{
+					type: "mcp_approval_response",
+					id: "mcp_approval_response_123",
+					approval_request_id: "mcp_approval_request_123",
+					approve: true,
+				},
+			],
+			tools: [
+				{
+					type: "mcp",
+					server_label: "gitmcp",
+					server_url: "https://gitmcp.io/openai/tiktoken",
+					allowed_tools: ["search_tiktoken_documentation", "fetch_tiktoken_documentation"],
+					require_approval: "always",
+				},
+			],
+		});
+
+		assert.ok(Array.isArray(response.output));
+		assert.ok(response.output.length >= 2);
+
+		// Check first output item (mcp_list_tools)
+		const listToolsOutput = response.output[0];
+		assert.equal(listToolsOutput.type, "mcp_list_tools");
+		assert.equal(listToolsOutput.server_label, "gitmcp");
+		assert.ok(listToolsOutput.id);
+		assert.ok(Array.isArray(listToolsOutput.tools));
+		assert.ok(listToolsOutput.tools.length > 0);
+
+		// Check that tools array contains expected tools
+		const toolNames = listToolsOutput.tools.map((tool) => tool.name);
+		assert.ok(toolNames.includes("fetch_tiktoken_documentation"));
+		assert.ok(toolNames.includes("search_tiktoken_documentation"));
+
+		// Check second output item (mcp_call)
+		const mcpCallOutput = response.output[1];
+		assert.equal(mcpCallOutput.type, "mcp_call");
+		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
+		assert.equal(mcpCallOutput.server_label, "gitmcp");
+		assert.ok(mcpCallOutput.id);
+		assert.equal(mcpCallOutput.arguments, "{}");
+		assert.ok(mcpCallOutput.output);
+		assert.ok(typeof mcpCallOutput.output === "string");
+		assert.ok(mcpCallOutput.output.length > 0);
+	});
+
+	it("MCP approval error handling", async function () {
+		const response = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			input: [
+				{
+					type: "message",
+					role: "user",
+					content: "how does tiktoken work?",
+				},
+				{
+					type: "mcp_approval_response",
+					id: "mcp_approval_response_123",
+					approval_request_id: "mcp_approval_request_123",
+					approve: true,
+				},
+			],
+			tools: [
+				{
+					type: "mcp",
+					server_label: "gitmcp",
+					server_url: "https://gitmcp.io/openai/tiktoken",
+					allowed_tools: ["search_tiktoken_documentation", "fetch_tiktoken_documentation"],
+					require_approval: "always",
+				},
+			],
+		});
+
+		assert.ok(response.error);
+		assert.equal(response.error.code, "server_error");
+		assert.equal(
+			response.error.message,
+			"MCP approval response for approval request 'mcp_approval_request_123' not found"
+		);
+	});
+
+	it("MCP approval request", async function () {
+		const response = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			input: "how does tiktoken work?",
+			tools: [
+				{
+					type: "mcp",
+					server_label: "gitmcp",
+					server_url: "https://gitmcp.io/openai/tiktoken",
+					allowed_tools: ["search_tiktoken_documentation", "fetch_tiktoken_documentation"],
+					require_approval: "always",
+				},
+			],
+		});
+
+		assert.ok(Array.isArray(response.output));
+		assert.ok(response.output.length >= 2);
+
+		// Check first output item (mcp_list_tools)
+		const listToolsOutput = response.output[0];
+		assert.equal(listToolsOutput.type, "mcp_list_tools");
+		assert.equal(listToolsOutput.server_label, "gitmcp");
+		assert.ok(listToolsOutput.id);
+		assert.ok(Array.isArray(listToolsOutput.tools));
+		assert.ok(listToolsOutput.tools.length > 0);
+
+		// Check that tools array contains expected tools
+		const toolNames = listToolsOutput.tools.map((tool) => tool.name);
+		assert.ok(toolNames.includes("fetch_tiktoken_documentation"));
+		assert.ok(toolNames.includes("search_tiktoken_documentation"));
+
+		// Check second output item (mcp_approval_request)
+		const approvalRequestOutput = response.output[1];
+		assert.equal(approvalRequestOutput.type, "mcp_approval_request");
+		assert.equal(approvalRequestOutput.name, "fetch_tiktoken_documentation");
+		assert.equal(approvalRequestOutput.server_label, "gitmcp");
+		assert.ok(approvalRequestOutput.id);
+		assert.ok(approvalRequestOutput.arguments);
+		assert.equal(typeof approvalRequestOutput.arguments, "string");
+
+		// Parse and validate the arguments
+		const argumentsJson = JSON.parse(approvalRequestOutput.arguments);
+		assert.ok(argumentsJson.root);
+	});
+
+	it("MCP auto approval", async function () {
+		const response = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			input: "how does tiktoken work?",
+			tools: [
+				{
+					type: "mcp",
+					server_label: "gitmcp",
+					server_url: "https://gitmcp.io/openai/tiktoken",
+					allowed_tools: ["search_tiktoken_documentation", "fetch_tiktoken_documentation"],
+					require_approval: "never",
+				},
+			],
+		});
+
+		assert.ok(Array.isArray(response.output));
+		assert.ok(response.output.length >= 2);
+
+		// Check first output item (mcp_list_tools)
+		const listToolsOutput = response.output[0];
+		assert.equal(listToolsOutput.type, "mcp_list_tools");
+		assert.equal(listToolsOutput.server_label, "gitmcp");
+		assert.ok(listToolsOutput.id);
+		assert.ok(Array.isArray(listToolsOutput.tools));
+		assert.ok(listToolsOutput.tools.length > 0);
+
+		// Check that tools array contains expected tools
+		const toolNames = listToolsOutput.tools.map((tool) => tool.name);
+		assert.ok(toolNames.includes("fetch_tiktoken_documentation"));
+		assert.ok(toolNames.includes("search_tiktoken_documentation"));
+
+		// Check second output item (mcp_call)
+		const mcpCallOutput = response.output[1];
+		assert.equal(mcpCallOutput.type, "mcp_call");
+		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
+		assert.equal(mcpCallOutput.server_label, "gitmcp");
+		assert.ok(mcpCallOutput.id);
+		assert.ok(mcpCallOutput.arguments);
+		assert.equal(typeof mcpCallOutput.arguments, "string");
+		assert.ok(mcpCallOutput.output);
+		assert.ok(typeof mcpCallOutput.output === "string");
+		assert.ok(mcpCallOutput.output.length > 0);
+
+		// Parse and validate the arguments
+		const argumentsJson = JSON.parse(mcpCallOutput.arguments);
+		assert.ok(argumentsJson.root);
+	});
+
+	it("MCP tools provided in input", async function () {
+		const response = await openai.responses.create({
+			model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+			input: [
+				{
+					id: "mcp_list_tools_8713ae5fbd20f7ebb68eb32a84bbb26f17cee1e0615bb762",
+					type: "mcp_list_tools",
+					server_label: "gitmcp",
+					tools: [
+						{
+							input_schema: {
+								type: "object",
+							},
+							name: "fetch_tiktoken_documentation",
+							description:
+								"Fetch entire documentation file from GitHub repository: openai/tiktoken. Useful for general questions. Always call this tool first if asked about openai/tiktoken.",
+						},
+						{
+							input_schema: {
+								type: "object",
+								properties: {
+									query: {
+										type: "string",
+										description: "The search query to find relevant documentation",
+									},
+								},
+								required: ["query"],
+								additionalProperties: false,
+								$schema: "http://json-schema.org/draft-07/schema#",
+							},
+							name: "search_tiktoken_documentation",
+							description:
+								"Semantically search within the fetched documentation from GitHub repository: openai/tiktoken. Useful for specific queries.",
+						},
+					],
+				},
+				{
+					type: "message",
+					role: "user",
+					content: "how does tiktoken work?",
+				},
+			],
+			tools: [
+				{
+					type: "mcp",
+					server_label: "gitmcp",
+					server_url: "https://gitmcp.io/openai/tiktoken",
+					allowed_tools: ["search_tiktoken_documentation", "fetch_tiktoken_documentation"],
+					require_approval: "always",
+				},
+			],
+		});
+
+		assert.ok(Array.isArray(response.output));
+		assert.ok(response.output.length >= 1);
+
+		// Check that the first output item is an approval request (not a list_tools call)
+		const approvalRequestOutput = response.output[0];
+		assert.equal(approvalRequestOutput.type, "mcp_approval_request");
+		assert.equal(approvalRequestOutput.name, "fetch_tiktoken_documentation");
+		assert.equal(approvalRequestOutput.server_label, "gitmcp");
+		assert.ok(approvalRequestOutput.id);
+		assert.ok(approvalRequestOutput.arguments);
+		assert.equal(typeof approvalRequestOutput.arguments, "string");
+
+		// Parse and validate the arguments
+		const argumentsJson = JSON.parse(approvalRequestOutput.arguments);
+		assert.ok(argumentsJson.root);
+	});
+});


### PR DESCRIPTION
I'm planning to do a small refacto of `responses.ts` which became unreadable with MCP stuff and I needed to ensure I'm not breaking things. This PR finally adds some tests for the basic examples.  I went for a very basic solution:
- Server must be running (`pnpm dev`) on `http://localhost:3000`
- `HF_TOKEN` environment variable set with your Hugging Face token
- Nothing is cached, meaning it cost $$$ to run the tests

It's fine for now. We won't run them in CI.

```bash
# Run all tests
pnpm test

# Run specific test patterns
pnpm test --grep "streaming"
pnpm test --grep "function"
pnpm test --grep "structured"
```