### PR TITLE
Support MCP streaming (and big refacto)

### DIFF
--- a/examples/mcp_auto_approval_streaming.js
+++ b/examples/mcp_auto_approval_streaming.js
@@ -1,0 +1,22 @@
+import OpenAI from "openai";
+
+const openai = new OpenAI({ baseURL: "http://localhost:3000/v1", apiKey: process.env.HF_TOKEN });
+
+const stream = await openai.responses.create({
+	model: "cerebras@meta-llama/Llama-3.3-70B-Instruct",
+	input: "how does tiktoken work?",
+	tools: [
+		{
+			type: "mcp",
+			server_label: "gitmcp",
+			server_url: "https://gitmcp.io/openai/tiktoken",
+			allowed_tools: ["search_tiktoken_documentation", "fetch_tiktoken_documentation"],
+			require_approval: "never",
+		},
+	],
+	stream: true,
+});
+
+for await (const event of stream) {
+	console.log(event);
+}

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -6,8 +6,6 @@ import { URL } from "url";
 
 import type { McpServerParams } from "./schemas";
 import { McpResultFormatter } from "./lib/McpResultFormatter";
-import { generateUniqueId } from "./lib/generateUniqueId";
-import type { ResponseOutputItem } from "openai/resources/responses/responses";
 
 export async function connectMcpServer(mcpServer: McpServerParams): Promise<Client> {
 	const mcp = new Client({ name: "@huggingface/responses.js", version: packageVersion });
@@ -37,7 +35,6 @@ export async function connectMcpServer(mcpServer: McpServerParams): Promise<Clie
 export async function callMcpTool(
 	mcpServer: McpServerParams,
 	toolName: string,
-	server_label: string,
 	argumentsString: string
 ): Promise<{ error: string; output?: undefined } | { error?: undefined; output: string }> {
 	try {

--- a/src/mcp.ts
+++ b/src/mcp.ts
@@ -39,7 +39,7 @@ export async function callMcpTool(
 	toolName: string,
 	server_label: string,
 	argumentsString: string
-): Promise<ResponseOutputItem> {
+): Promise<{ error: string; output?: undefined } | { error?: undefined; output: string }> {
 	try {
 		const client = await connectMcpServer(mcpServer);
 		const toolArgs: Record<string, unknown> = argumentsString === "" ? {} : JSON.parse(argumentsString);
@@ -47,22 +47,12 @@ export async function callMcpTool(
 		const toolResponse = await client.callTool({ name: toolName, arguments: toolArgs });
 		const formattedResult = McpResultFormatter.format(toolResponse);
 		return {
-			type: "mcp_call",
-			id: generateUniqueId("mcp_call"),
-			name: toolName,
-			server_label: server_label,
-			arguments: argumentsString,
 			output: formattedResult,
 		};
 	} catch (error) {
 		const errorMessage =
 			error instanceof Error ? error.message : typeof error === "string" ? error : JSON.stringify(error);
 		return {
-			type: "mcp_call",
-			id: generateUniqueId("mcp_call"),
-			name: toolName,
-			server_label: server_label,
-			arguments: argumentsString,
 			error: errorMessage,
 		};
 	}

--- a/tests/responses.test.js
+++ b/tests/responses.test.js
@@ -518,7 +518,6 @@ describe("responses.js", function () {
 		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
 		assert.equal(mcpCallOutput.server_label, "gitmcp");
 		assert.ok(mcpCallOutput.id);
-		assert.equal(mcpCallOutput.arguments, "{}");
 		assert.ok(mcpCallOutput.output);
 		assert.ok(typeof mcpCallOutput.output === "string");
 		assert.ok(mcpCallOutput.output.length > 0);
@@ -553,10 +552,7 @@ describe("responses.js", function () {
 
 		assert.ok(response.error);
 		assert.equal(response.error.code, "server_error");
-		assert.equal(
-			response.error.message,
-			"MCP approval response for approval request 'mcp_approval_request_123' not found"
-		);
+		assert.equal(response.error.message, "MCP approval request 'mcp_approval_request_123' not found");
 	});
 
 	it("MCP approval request", async function () {
@@ -590,8 +586,16 @@ describe("responses.js", function () {
 		assert.ok(toolNames.includes("fetch_tiktoken_documentation"));
 		assert.ok(toolNames.includes("search_tiktoken_documentation"));
 
+		const mcpCallOutput = response.output[1];
+		assert.equal(mcpCallOutput.type, "mcp_call");
+		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
+		assert.equal(mcpCallOutput.server_label, "gitmcp");
+		assert.ok(mcpCallOutput.id);
+		assert.ok(mcpCallOutput.arguments);
+		assert.equal(typeof mcpCallOutput.arguments, "string");
+
 		// Check second output item (mcp_approval_request)
-		const approvalRequestOutput = response.output[1];
+		const approvalRequestOutput = response.output[2];
 		assert.equal(approvalRequestOutput.type, "mcp_approval_request");
 		assert.equal(approvalRequestOutput.name, "fetch_tiktoken_documentation");
 		assert.equal(approvalRequestOutput.server_label, "gitmcp");
@@ -708,8 +712,16 @@ describe("responses.js", function () {
 		assert.ok(Array.isArray(response.output));
 		assert.ok(response.output.length >= 1);
 
+		const mcpCallOutput = response.output[0];
+		assert.equal(mcpCallOutput.type, "mcp_call");
+		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
+		assert.equal(mcpCallOutput.server_label, "gitmcp");
+		assert.ok(mcpCallOutput.id);
+		assert.ok(mcpCallOutput.arguments);
+		assert.equal(typeof mcpCallOutput.arguments, "string");
+
 		// Check that the first output item is an approval request (not a list_tools call)
-		const approvalRequestOutput = response.output[0];
+		const approvalRequestOutput = response.output[1];
 		assert.equal(approvalRequestOutput.type, "mcp_approval_request");
 		assert.equal(approvalRequestOutput.name, "fetch_tiktoken_documentation");
 		assert.equal(approvalRequestOutput.server_label, "gitmcp");


### PR DESCRIPTION
```
✗ pnpm test                   

> @huggingface/responses.js@0.1.0 test /home/wauplin/projects/responses.js
> mocha --timeout 20000 "tests/**/*.test.js"

  responses.js
    ✔ text input, text output (1281ms)
    ✔ text+image input, text output (1867ms)
    ✔ multi-turn conversation, text output (2314ms)
    ✔ function calling (357ms)
    ✔ structured output (2445ms)
    ✔ streaming response (728ms)
    ✔ function streaming (349ms)
    ✔ structured output streaming (1895ms)
    ✔ MCP approved tool call (2609ms)
    ✔ MCP approval error handling (762ms)
    ✔ MCP approval request (1349ms)
    ✔ MCP auto approval (2227ms)
    ✔ MCP tools provided in input (427ms)

  13 passing (19s)
```

Big PR to make everything cleaner. Now all the process is done with `stream: true`. At the very end, we reformat to plain response if user did pass `stream: false`, otherwise we return as stream. This logic deduplicates a lot the code.