### PR TITLE
Switch to OpenAI js client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # responses.js
 
-A lightweight Express.js server that implements OpenAI's Responses API, built on top of Chat Completions and powered by Hugging Face Inference Providers.
+A lightweight Express.js server that implements a translation layer between the two main LLM APIs currently available. Works with any Chat Completion API, whether it's a local LLM or the cloud provider of your choice.
 
 ## ✨ Features
 
 - **ResponsesAPI**: Partial implementation of [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses), on top of Chat Completion API
-- **Inference Providers**: Powered by Hugging Face Inference Providers
+- **Provider Agnostic**: Works with any Chat Completion API (local or remote)
 - **Streaming Support**: Support for streamed responses
 - **Structured Output**: Support for structured data responses (e.g. jsonschema)
 - **Function Calling**: Tool and function calling capabilities
@@ -69,8 +69,8 @@ pnpm run example function_streaming
 ### Important Notes
 
 - Server must be running (`pnpm dev`) on `http://localhost:3000`
-- `HF_TOKEN` environment variable set with your Hugging Face token
-- Tests use real inference providers and will incur costs
+- `API_KEY` environment variable set with your LLM provider's API key
+- Tests use real inference providers and may incur costs
 - Tests are not run in CI due to billing requirements
 
 ### Running Tests
@@ -99,7 +99,7 @@ Experience the API through our interactive web interface, adapted from the [open
 ```bash
 # Create demo/.env
 cat > demo/.env << EOF
-MODEL="CohereLabs/c4ai-command-a-03-2025"
+MODEL="moonshotai/Kimi-K2-Instruct:groq"
 OPENAI_BASE_URL=http://localhost:3000/v1
 OPENAI_API_KEY=${HF_TOKEN:-<your-huggingface-token>}
 EOF
@@ -187,4 +187,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - Based on OpenAI's [Responses API specification](https://platform.openai.com/docs/api-reference/responses)
 - Built on top of [OpenAI's nodejs client](https://github.com/openai/openai-node)
 - Demo UI adapted from [openai-responses-starter-app](https://github.com/openai/openai-responses-starter-app)
-- Built on top of [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/index)

--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ responses.js/
 - [x] Multi-turn conversation fixes for text messages + tool calls
 - [x] Correctly return "usage" field
 - [x] MCP support (non-streaming)
-- [ ] MCP support (streaming)
+- [x] MCP support (streaming)
 - [ ] Tools execution (web search, file search, image generation, code interpreter)
 - [ ] Background mode support
 - [ ] Additional API routes (GET, DELETE, CANCEL, LIST responses)
@@ -185,6 +185,6 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## 🙏 Acknowledgments
 
 - Based on OpenAI's [Responses API specification](https://platform.openai.com/docs/api-reference/responses)
-- Built on top of [OpenAI's nodejs client's Types](https://github.com/openai/openai-node)
+- Built on top of [OpenAI's nodejs client](https://github.com/openai/openai-node)
 - Demo UI adapted from [openai-responses-starter-app](https://github.com/openai/openai-responses-starter-app)
 - Built on top of [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers/index)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A lightweight Express.js server that implements a translation layer between the two main LLM APIs currently available. Works with any Chat Completion API, whether it's a local LLM or the cloud provider of your choice.
 
+## 🎮 Live Demo
+
+[**Try responses.js right now, no installation needed!**](https://huggingface.co/spaces/Wauplin/responses.js)
+
 ## ✨ Features
 
 - **ResponsesAPI**: Partial implementation of [OpenAI's Responses API](https://platform.openai.com/docs/api-reference/responses), on top of Chat Completion API
@@ -10,9 +14,10 @@ A lightweight Express.js server that implements a translation layer between the 
 - **Structured Output**: Support for structured data responses (e.g. jsonschema)
 - **Function Calling**: Tool and function calling capabilities
 - **Multi-modal Input**: Text and image input support
+- **Remote MCP**: Execute MCP tool calls remotely
 - **Demo UI**: Interactive web interface for testing
 
-Not implemented: remote function calling, MCP server, file upload, stateful API, etc.
+Not implemented: remote function calling, file upload, stateful API, etc.
 
 ## 🚀 Quick Start
 

--- a/examples/image.js
+++ b/examples/image.js
@@ -3,11 +3,10 @@ import OpenAI from "openai";
 const openai = new OpenAI({ baseURL: "http://localhost:3000/v1", apiKey: process.env.HF_TOKEN });
 
 const response = await openai.responses.create({
-	model: "meta-llama/Llama-4-Scout-17B-16E-Instruct:cerebras",
+	model: "meta-llama/Llama-4-Scout-17B-16E-Instruct:groq",
 	input: [
 		{
 			role: "user",
-			type: "message",
 			content: [
 				{ type: "input_text", text: "what is in this image?" },
 				{

--- a/examples/image.js
+++ b/examples/image.js
@@ -3,10 +3,11 @@ import OpenAI from "openai";
 const openai = new OpenAI({ baseURL: "http://localhost:3000/v1", apiKey: process.env.HF_TOKEN });
 
 const response = await openai.responses.create({
-	model: "Qwen/Qwen2.5-VL-7B-Instruct",
+	model: "meta-llama/Llama-4-Scout-17B-16E-Instruct:cerebras",
 	input: [
 		{
 			role: "user",
+			type: "message",
 			content: [
 				{ type: "input_text", text: "what is in this image?" },
 				{

--- a/package.json
+++ b/package.json
@@ -58,8 +58,6 @@
 	"author": "Hugging Face",
 	"license": "MIT",
 	"dependencies": {
-		"@huggingface/inference": "^4.3.1",
-		"@huggingface/tasks": "^0.19.22",
 		"@modelcontextprotocol/sdk": "^1.15.0",
 		"express": "^4.21.2",
 		"openai": "^5.8.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,12 +8,6 @@ importers:
 
   .:
     dependencies:
-      '@huggingface/inference':
-        specifier: ^4.3.1
-        version: 4.3.1
-      '@huggingface/tasks':
-        specifier: ^0.19.22
-        version: 0.19.22
       '@modelcontextprotocol/sdk':
         specifier: ^1.15.0
         version: 1.15.0
@@ -257,17 +251,6 @@ packages:
   '@eslint/plugin-kit@0.3.3':
     resolution: {integrity: sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@huggingface/inference@4.3.1':
-    resolution: {integrity: sha512-wn5ErcX+HTeAYfNIkgjl6pkzGvTeskKRoCFodSmEfa+SmZnMo0/YDP46Ivnz2JV6DJwMd3naOtgYH6WZVD3qoQ==}
-    engines: {node: '>=18'}
-
-  '@huggingface/jinja@0.5.0':
-    resolution: {integrity: sha512-Ptc03/jGRiYRoi0bUYKZ14MkDslsBRT24oxmsvUlfYrvQMldrxCevhPnT+hfX8awKTT8/f/0ZBBWldoeAcMHdQ==}
-    engines: {node: '>=18'}
-
-  '@huggingface/tasks@0.19.22':
-    resolution: {integrity: sha512-jtRXsJZTES01X4gJ5VOUnEm3ONyyfXUcWKObbWkr/SQmjaH/kxtWqc2zVWKaxL4QLoXqXJ+T+Pi5xupMStSudQ==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -1832,15 +1815,6 @@ snapshots:
     dependencies:
       '@eslint/core': 0.15.1
       levn: 0.4.1
-
-  '@huggingface/inference@4.3.1':
-    dependencies:
-      '@huggingface/jinja': 0.5.0
-      '@huggingface/tasks': 0.19.22
-
-  '@huggingface/jinja@0.5.0': {}
-
-  '@huggingface/tasks@0.19.22': {}
 
   '@humanfs/core@0.19.1': {}
 

--- a/src/routes/landingPageHtml.ts
+++ b/src/routes/landingPageHtml.ts
@@ -464,7 +464,7 @@ export function getLandingPageHtml(req: Request, res: Response): void {
   <main>
     <section class="hero">
       <h2>OpenAI-compatible Responses API</h2>
-      <p><b>responses.js</b> is an open-source, lightweight server implementing OpenAI's Responses API, built on top of Chat Completions and powered by Hugging Face Inference Providers.</p>
+      <p><b>responses.js</b> is an open-source, lightweight translation layer between the two main LLM APIs currently available. Works with any Chat Completion API, whether it's a local LLM or the cloud provider of your choice.</p>
       <div class="api-endpoint-box">
         <button class="copy-endpoint-btn" onclick="copyEndpointUrl(this)">Copy</button>
         <div><b>API Endpoint:</b></div>
@@ -479,13 +479,13 @@ export function getLandingPageHtml(req: Request, res: Response): void {
           <b>OpenAI-compatible</b><br>Stateless implementation of the <a href="https://platform.openai.com/docs/api-reference/responses" target="_blank">Responses API</a>
         </div>
         <div class="feature-card">
-          <b>Inference Providers</b><br>Powered by Hugging Face Inference Providers
+          <b>Provider Agnostic</b><br>Works with any Chat Completion API (local or remote).
         </div>
         <div class="feature-card">
-          <b>Multi-modal</b><br>Text and image input support
+          <b>Multi-modal, streaming, structured output</b><br>Supports text and image inputs, streaming output, JSON schema, and function calling.
         </div>
         <div class="feature-card">
-          <b>Streaming, & Structured Output</b><br>Supports streaming, JSON schema, and function calling
+          <b>Remote MCP</b><br>Server-side MCP tool execution.
         </div>
       </div>
     </section>

--- a/src/routes/landingPageHtml.ts
+++ b/src/routes/landingPageHtml.ts
@@ -510,7 +510,7 @@ client = OpenAI(
 )
 
 response = client.responses.create(
-    model="Qwen/Qwen2.5-VL-7B-Instruct",
+    model="moonshotai/Kimi-K2-Instruct:groq",
     instructions="You are a helpful assistant.",
     input="Tell me a three sentence bedtime story about a unicorn.",
 )
@@ -556,7 +556,7 @@ client = OpenAI(
 )
 
 response = client.responses.create(
-    model="Qwen/Qwen2.5-VL-7B-Instruct",
+    model="moonshotai/Kimi-K2-Instruct:groq",
     input=[
         {
             "role": "developer",
@@ -582,7 +582,7 @@ client = OpenAI(
 )
 
 stream = client.responses.create(
-    model="Qwen/Qwen2.5-VL-7B-Instruct",
+    model="moonshotai/Kimi-K2-Instruct:groq",
     input=[
         {
             "role": "user",
@@ -621,7 +621,7 @@ tools = [
 ]
 
 response = client.responses.create(
-    model="meta-llama/Llama-3.3-70B-Instruct:cerebras",
+    model="moonshotai/Kimi-K2-Instruct:groq",
     tools=tools,
     input="What is the weather like in Boston today?",
     tool_choice="auto",
@@ -645,7 +645,7 @@ class CalendarEvent(BaseModel):
     participants: list[str]
 
 response = client.responses.parse(
-    model="meta-llama/Meta-Llama-3-70B-Instruct:novita",
+    model="moonshotai/Kimi-K2-Instruct:groq",
     input=[
         {"role": "system", "content": "Extract the event information."},
         {
@@ -668,7 +668,7 @@ client = OpenAI(
 )
 
 response = client.responses.create(
-    model="meta-llama/Llama-3.3-70B-Instruct:cerebras",
+    model="moonshotai/Kimi-K2-Instruct:groq",
     input="how does tiktoken work?",
     tools=[
         {

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -250,6 +250,7 @@ async function* innerRunStream(
 								tool_call_id: item.call_id,
 							};
 						case "message":
+						case undefined:
 							if (item.role === "assistant" || item.role === "user" || item.role === "system") {
 								const content =
 									typeof item.content === "string"
@@ -480,7 +481,6 @@ async function* handleOneTurnStream(
 		baseURL: process.env.OPENAI_BASE_URL ?? "https://router.huggingface.co/v1",
 		apiKey: apiKey,
 	});
-	console.log(`payload: ${JSON.stringify(payload)}`);
 	const stream = await client.chat.completions.create(payload);
 	let previousInputTokens = responseObject.usage?.input_tokens ?? 0;
 	let previousOutputTokens = responseObject.usage?.output_tokens ?? 0;

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -281,9 +281,8 @@ async function* innerRunStream(
 													}
 												})
 												.filter((item) => {
-													item !== undefined;
+													return item !== undefined;
 												});
-
 								return {
 									role: item.role,
 									content,
@@ -481,6 +480,7 @@ async function* handleOneTurnStream(
 		baseURL: process.env.OPENAI_BASE_URL ?? "https://router.huggingface.co/v1",
 		apiKey: apiKey,
 	});
+	console.log(`payload: ${JSON.stringify(payload)}`);
 	const stream = await client.chat.completions.create(payload);
 	let previousInputTokens = responseObject.usage?.input_tokens ?? 0;
 	let previousOutputTokens = responseObject.usage?.output_tokens ?? 0;

--- a/tests/responses.test.js
+++ b/tests/responses.test.js
@@ -36,7 +36,7 @@ describe("responses.js", function () {
 
 	it("text+image input, text output", async function () {
 		const response = await openai.responses.create({
-			model: "meta-llama/Llama-4-Scout-17B-16E-Instruct:cerebras",
+			model: "meta-llama/Llama-4-Scout-17B-16E-Instruct:groq",
 			input: [
 				{
 					role: "user",
@@ -571,7 +571,7 @@ describe("responses.js", function () {
 		});
 
 		assert.ok(Array.isArray(response.output));
-		assert.ok(response.output.length >= 2);
+		assert.ok(response.output.length === 2);
 
 		// Check first output item (mcp_list_tools)
 		const listToolsOutput = response.output[0];
@@ -586,16 +586,8 @@ describe("responses.js", function () {
 		assert.ok(toolNames.includes("fetch_tiktoken_documentation"));
 		assert.ok(toolNames.includes("search_tiktoken_documentation"));
 
-		const mcpCallOutput = response.output[1];
-		assert.equal(mcpCallOutput.type, "mcp_call");
-		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
-		assert.equal(mcpCallOutput.server_label, "gitmcp");
-		assert.ok(mcpCallOutput.id);
-		assert.ok(mcpCallOutput.arguments);
-		assert.equal(typeof mcpCallOutput.arguments, "string");
-
 		// Check second output item (mcp_approval_request)
-		const approvalRequestOutput = response.output[2];
+		const approvalRequestOutput = response.output[1];
 		assert.equal(approvalRequestOutput.type, "mcp_approval_request");
 		assert.equal(approvalRequestOutput.name, "fetch_tiktoken_documentation");
 		assert.equal(approvalRequestOutput.server_label, "gitmcp");
@@ -710,18 +702,10 @@ describe("responses.js", function () {
 		});
 
 		assert.ok(Array.isArray(response.output));
-		assert.ok(response.output.length >= 1);
-
-		const mcpCallOutput = response.output[0];
-		assert.equal(mcpCallOutput.type, "mcp_call");
-		assert.equal(mcpCallOutput.name, "fetch_tiktoken_documentation");
-		assert.equal(mcpCallOutput.server_label, "gitmcp");
-		assert.ok(mcpCallOutput.id);
-		assert.ok(mcpCallOutput.arguments);
-		assert.equal(typeof mcpCallOutput.arguments, "string");
+		assert.ok(response.output.length === 1);
 
 		// Check that the first output item is an approval request (not a list_tools call)
-		const approvalRequestOutput = response.output[1];
+		const approvalRequestOutput = response.output[0];
 		assert.equal(approvalRequestOutput.type, "mcp_approval_request");
 		assert.equal(approvalRequestOutput.name, "fetch_tiktoken_documentation");
 		assert.equal(approvalRequestOutput.server_label, "gitmcp");

--- a/tests/responses.test.js
+++ b/tests/responses.test.js
@@ -36,7 +36,7 @@ describe("responses.js", function () {
 
 	it("text+image input, text output", async function () {
 		const response = await openai.responses.create({
-			model: "Qwen/Qwen2.5-VL-7B-Instruct",
+			model: "meta-llama/Llama-4-Scout-17B-16E-Instruct:cerebras",
 			input: [
 				{
 					role: "user",


### PR DESCRIPTION
I do think that since we have a proper "auto" route with provider selection, it's preferable to use that one and use the official OpenAI client.

Few benefits:
- we are 100% sure the typing is correct => that's the most important benefit I believe
- no need to reimplement the `model:provider` syntax => we just forward it to router.hf.co/v1/chat/completions
- it allows using responses.js with any chat completion API (typically a local LLM) while still defaulting to HF


I also fixed some tests in the meantime (I think they were already broken on main...) + remove any `@huggingface/...` dependencies.