### PR TITLE
Make structured output / function calling non-strict

### DIFF
--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -359,7 +359,7 @@ async function* innerRunStream(
 							description: req.body.text.format.description,
 							name: req.body.text.format.name,
 							schema: req.body.text.format.schema,
-							strict: req.body.text.format.strict,
+							strict: false, // req.body.text.format.strict,
 						},
 					}
 				: { type: req.body.text.format.type }

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -125,8 +125,11 @@ async function* runCreateResponseStream(
 		console.error("Error in stream:", error);
 
 		const message =
-			typeof error === "object" && error && "message" in error && typeof (error as any).message === "string"
-				? (error as any).message
+			typeof error === "object" &&
+			error &&
+			"message" in error &&
+			typeof (error as { message: unknown }).message === "string"
+				? (error as { message: string }).message
 				: "An error occurred in stream";
 
 		responseObject.status = "failed";

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -207,7 +207,7 @@ export const createResponseParamsSchema = z.object({
 				z.object({
 					name: z.string(),
 					parameters: z.record(z.any()),
-					strict: z.boolean().optional(),
+					strict: z.boolean().default(false),
 					type: z.literal("function"),
 					description: z.string().optional(),
 				}),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -207,7 +207,7 @@ export const createResponseParamsSchema = z.object({
 				z.object({
 					name: z.string(),
 					parameters: z.record(z.any()),
-					strict: z.boolean().default(true),
+					strict: z.boolean().optional(),
 					type: z.literal("function"),
 					description: z.string().optional(),
 				}),


### PR DESCRIPTION
cc @hanouticelina @SBrandeis 

let's not forward the `strict` property as it might not be supported by the provider. By default Pydantic sets it to `strict: true` but for now ok to ignore it I think.

For reference, in the Responses API the default is `strict: false` for structured output:

<img width="960" height="323" alt="image" src="https://github.com/user-attachments/assets/61c766ac-6f7b-431a-9b29-0974af145a9b" />

and `strict: true` for function calling:

<img width="1068" height="687" alt="image" src="https://github.com/user-attachments/assets/5287bf1c-7db1-400e-bcf1-d786f70962e5" />


Current solution is to set it to `false` no matter what
