### PR TITLE
Forward user headers

### DIFF
--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -44,6 +44,12 @@ const NOT_FORWARDED_HEADERS = [
 	"content-length",
 	"content-type",
 	"host",
+	"keep-alive",
+	"te",
+	"trailer",
+	"trailers",
+	"transfer-encoding",
+	"upgrade",
 ];
 
 export const postCreateResponse = async (

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -36,7 +36,7 @@ type IncompleteResponse = Omit<Response, "incomplete_details" | "output_text" | 
 const SEQUENCE_NUMBER_PLACEHOLDER = -1;
 
 // All headers are forwarded by default, except these ones.
-const NOT_FORWARDED_HEADERS = [
+const NOT_FORWARDED_HEADERS = new Set([
 	"accept",
 	"accept-encoding",
 	"authorization",
@@ -50,7 +50,7 @@ const NOT_FORWARDED_HEADERS = [
 	"trailers",
 	"transfer-encoding",
 	"upgrade",
-];
+]);
 
 export const postCreateResponse = async (
 	req: ValidatedRequest<CreateResponseParams>,
@@ -188,7 +188,7 @@ async function* innerRunStream(
 
 	// Forward headers (except authorization handled separately)
 	const defaultHeaders = Object.fromEntries(
-		Object.entries(req.headers).filter(([key]) => !NOT_FORWARDED_HEADERS.includes(key.toLowerCase()))
+		Object.entries(req.headers).filter(([key]) => !NOT_FORWARDED_HEADERS.has(key.toLowerCase()))
 	) as Record<string, string>;
 
 	// Return early if not supported param


### PR DESCRIPTION
cc @SBrandeis 

Headers from the user are forwarded to the chat completion API.

Only a few ones are not forwarded:
- accept, accept-encoding => will be added by openai JS SDK
- authorization => handled separately
- connection => we always want to be "keep-alive" for streaming => done by openai SDK
- content-length / content-type => forwarded content is not the same, hence doesn't make sense to forward these
- host => not the same host

This will be useful in particular to forward `X-HF-Bill-To`