### PR TITLE
Accept any logprobs in output_text input

### DIFF
--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -101,8 +101,8 @@ export const createResponseParamsSchema = z.object({
 							z.object({
 								type: z.literal("output_text"),
 								text: z.string(),
-								annotations: z.array(z.object({})).nullable().optional(), // TODO: incomplete
-								logprobs: z.array(z.object({})).nullable().optional(), // TODO: incomplete
+								annotations: z.array(z.record(z.any())).nullable().optional(), // TODO: incomplete
+								logprobs: z.array(z.record(z.any())).nullable().optional(), // TODO: incomplete
 							}),
 							z.object({
 								type: z.literal("refusal"),


### PR DESCRIPTION
Accept `z.record(z.any())` instead of `z.object({})`. We won't check format for that as we don't use the values at all. Would still be good to check what is the data we should expect.


For the record,  I could not find any mentions in the docs of passing an `"output_text"` object in the input list. I checked here: https://platform.openai.com/docs/api-reference/responses/create. However I'm pretty sure that at some point I saw something about it, otherwise I wouldn't have add it in the first place. Curious if it disappeared from the docs.


(follow-up of https://github.com/huggingface/responses.js/pull/21)
