### PR TITLE
Fix server crash on missing Authorization header

### DIFF
--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -179,11 +179,7 @@ async function* innerRunStream(
 	// Retrieve API key from headers
 	const apiKey = req.headers.authorization?.split(" ")[1];
 	if (!apiKey) {
-		res.status(401).json({
-			success: false,
-			error: "Unauthorized",
-		});
-		return;
+		throw new Error("Unauthorized: Missing or invalid Authorization header");
 	}
 
 	// Forward headers (except authorization handled separately)

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -72,9 +72,17 @@ export const postCreateResponse = async (
 	} else {
 		console.debug("Non-stream request");
 		for await (const event of events) {
-			if (event.type === "response.completed" || event.type === "response.failed") {
+			if (event.type === "response.failed") {
 				console.debug(event.type);
-				res.json(event.response);
+				const message = event.response.error?.message;
+				const isUnauthorized = typeof message === "string" && message.startsWith("Unauthorized:");
+				res.status(isUnauthorized ? 401 : 500).json(event.response);
+				return;
+			}
+			if (event.type === "response.completed") {
+				console.debug(event.type);
+				res.status(200).json(event.response);
+				return;
 			}
 		}
 	}

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -56,6 +56,20 @@ export const postCreateResponse = async (
 	req: ValidatedRequest<CreateResponseParams>,
 	res: ExpressResponse
 ): Promise<void> => {
+	// For stream requests, validate authorization *before* setting SSE headers.
+	// Once headers are sent, we can't switch to a 401 response.
+	if (req.body.stream) {
+		const apiKey = req.headers.authorization?.split(" ")[1];
+		if (!apiKey) {
+			res.status(401).json({
+				error: {
+					message: "Unauthorized: Missing or invalid Authorization header",
+				},
+			});
+			return;
+		}
+	}
+
 	// To avoid duplicated code, we run all requests as stream.
 	const events = runCreateResponseStream(req, res);
 


### PR DESCRIPTION
## Summary
  - Fix server crash when requests arrive without a valid Authorization header
  - The `innerRunStream` generator was sending a 401 response directly and returning, but the outer
  `runCreateResponseStream` continued and yielded `response.completed`, causing `postCreateResponse` to
  call `res.json()` a second time
  - Now throws an error instead, which gets caught and converted to a proper `response.failed` event

  ## Test plan
  - [ ] Send a request without an Authorization header - should return a failed response instead of
  crashing
  - [ ] Send a request with a valid Authorization header - should work as befor