### PR TITLE
Fix crash when Authorization header is missing for /v1/responses requests

### DIFF
--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -56,8 +56,23 @@ export const postCreateResponse = async (
 	req: ValidatedRequest<CreateResponseParams>,
 	res: ExpressResponse
 ): Promise<void> => {
+	// This service doesn't validate the token, but it cannot proceed without one.
+	// Fail early before we start streaming (once we write SSE bytes, we can't return a 401).
+	const authorizationHeader = req.headers.authorization;
+	const apiKey =
+		typeof authorizationHeader === "string" && authorizationHeader.startsWith("Bearer ")
+			? authorizationHeader.slice("Bearer ".length).trim()
+			: undefined;
+	if (!apiKey) {
+		res.status(401).json({
+			success: false,
+			error: "Unauthorized",
+		});
+		return;
+	}
+
 	// To avoid duplicated code, we run all requests as stream.
-	const events = runCreateResponseStream(req, res);
+	const events = runCreateResponseStream(req, res, apiKey);
 
 	// Then we return in the correct format depending on the user 'stream' flag.
 	if (req.body.stream) {
@@ -88,7 +103,8 @@ export const postCreateResponse = async (
  */
 async function* runCreateResponseStream(
 	req: ValidatedRequest<CreateResponseParams>,
-	res: ExpressResponse
+	res: ExpressResponse,
+	apiKey: string
 ): AsyncGenerator<PatchedResponseStreamEvent> {
 	let sequenceNumber = 0;
 	// Prepare response object that will be iteratively populated
@@ -134,7 +150,7 @@ async function* runCreateResponseStream(
 
 	// Any events (LLM call, MCP call, list tools, etc.)
 	try {
-		for await (const event of innerRunStream(req, res, responseObject)) {
+		for await (const event of innerRunStream(req, res, responseObject, apiKey)) {
 			yield { ...event, sequence_number: sequenceNumber++ };
 		}
 	} catch (error) {
@@ -174,17 +190,9 @@ async function* runCreateResponseStream(
 async function* innerRunStream(
 	req: ValidatedRequest<CreateResponseParams>,
 	res: ExpressResponse,
-	responseObject: IncompleteResponse
+	responseObject: IncompleteResponse,
+	apiKey: string
 ): AsyncGenerator<PatchedResponseStreamEvent> {
-	// Retrieve API key from headers
-	const apiKey = req.headers.authorization?.split(" ")[1];
-	if (!apiKey) {
-		res.status(401).json({
-			success: false,
-			error: "Unauthorized",
-		});
-		return;
-	}
 
 	// Forward headers (except authorization handled separately)
 	const defaultHeaders = Object.fromEntries(

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -52,17 +52,28 @@ const NOT_FORWARDED_HEADERS = new Set([
 	"upgrade",
 ]);
 
+function getBearerToken(authorizationHeader: unknown): string | undefined {
+	if (typeof authorizationHeader !== "string") {
+		return undefined;
+	}
+
+	// We don't validate the token - just extract it in a safe, predictable way.
+	const match = authorizationHeader.match(/^Bearer\s+(.+)$/i);
+	if (!match) {
+		return undefined;
+	}
+
+	const token = match[1].trim();
+	return token.length > 0 ? token : undefined;
+}
+
 export const postCreateResponse = async (
 	req: ValidatedRequest<CreateResponseParams>,
 	res: ExpressResponse
 ): Promise<void> => {
 	// This service doesn't validate the token, but it cannot proceed without one.
 	// Fail early before we start streaming (once we write SSE bytes, we can't return a 401).
-	const authorizationHeader = req.headers.authorization;
-	const apiKey =
-		typeof authorizationHeader === "string" && authorizationHeader.startsWith("Bearer ")
-			? authorizationHeader.slice("Bearer ".length).trim()
-			: undefined;
+		const apiKey = getBearerToken(req.headers.authorization);
 	if (!apiKey) {
 		res.status(401).json({
 			success: false,

--- a/tests/00-missing-auth-header.test.js
+++ b/tests/00-missing-auth-header.test.js
@@ -1,0 +1,51 @@
+import { strict as assert } from "assert";
+
+const BASE_URL = process.env.RESPONSES_BASE_URL ?? "http://localhost:3000";
+
+describe("missing Authorization header", function () {
+	// Matches the existing test suite behavior: tests expect a running dev server.
+	before(async function () {
+		try {
+			const response = await fetch(`${BASE_URL}/`);
+			if (response.status !== 200) {
+				throw new Error(`Server returned status ${response.status}`);
+			}
+		} catch (error) {
+			console.error("❌ Server is not running. Please start the server with 'pnpm dev' before running the tests.");
+			throw error;
+		}
+	});
+
+	it("streaming request returns 401 (does not start an SSE stream)", async function () {
+		const res = await fetch(`${BASE_URL}/v1/responses`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+				Accept: "text/event-stream",
+			},
+			body: JSON.stringify({ model: "gpt-4.1-mini", input: "hi", stream: true }),
+		});
+
+		assert.equal(res.status, 401);
+
+		const contentType = res.headers.get("content-type") ?? "";
+		assert.ok(!contentType.includes("text/event-stream"), `Expected non-SSE response, got content-type: ${contentType}`);
+	});
+
+	it("non-streaming request returns 401 and server remains healthy", async function () {
+		const res = await fetch(`${BASE_URL}/v1/responses`, {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({ model: "gpt-4.1-mini", input: "hi" }),
+		});
+
+		assert.equal(res.status, 401);
+
+		// Regression: the handler must not crash the whole process after responding.
+		// (The bug was triggering "Cannot set headers after they are sent to the client".)
+		const healthRes = await fetch(`${BASE_URL}/health`);
+		assert.equal(healthRes.status, 200);
+	});
+});


### PR DESCRIPTION
Fixes: https://github.com/huggingface/responses.js/issues/28

 This PR fixes a bug where `POST /v1/responses` could crash the server when the `Authorization` header is missing—especially in streaming mode where response headers may already be sent.

 #### What changed
 - Added regression coverage to ensure both **streaming** (`Accept: text/event-stream`) and **non-streaming** requests **return 401** when `Authorization` is missing (instead of crashing).
 - Fail early in `postCreateResponse` *before* emitting any SSE bytes, preventing `Cannot set headers after they are sent to the client`.
 - Pass the extracted bearer token down explicitly into the streaming execution path (so deeper code doesn’t try to write to the HTTP response).
 - Centralized bearer-token extraction in a small helper for consistent parsing.

 #### Why
 Once streaming starts, the server cannot safely change status/headers. Previously, missing auth could be handled too late (inside the streaming logic), leading to attempts to set headers after data was already
 written and causing instability/crashes.

 #### How to test
 - Start the server `pnpm dev`
 - `pnpm test -- --grep "Authorization"` (or run the specific missing-auth test file)
 - Manual repro:
   - Streaming request without `Authorization` should respond `401` (no SSE stream started) 
  ```
   curl -N -i \
   -X POST http://localhost:3000/v1/responses \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream' \
   -d '{"model":"gpt-4.1-mini","input":"hi","stream":true}'
  ```
   - Non-stream request without `Authorization` should respond `401` and the server should remain running
  ```
curl -i \
   -X POST http://localhost:3000/v1/responses \
   -H 'Content-Type: application/json' \
   -d '{"model":"gpt-4.1-mini","input":"hi","stream":false}'
  ```