### PR TITLE
feat: add prod-v2 ALB override for the dedicated hub-utils cluster

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,4 +71,4 @@ jobs:
           display-workflow-run-url-interval: 10s
           ref: refs/heads/main
           token: ${{ secrets.GIT_TOKEN_INFRA_DEPLOYMENT }}
-          inputs: '{"path": "hub-integrations/responses-js/responses-js.yaml", "value": ${{ env.VALUES }}, "url": "${{ github.event.head_commit.url }}"}'
+          inputs: '{"path": "hub-integrations/responses-js/*.yaml", "value": ${{ env.VALUES }}, "url": "${{ github.event.head_commit.url }}"}'

--- a/chart/env/prod-v2.yaml
+++ b/chart/env/prod-v2.yaml
@@ -1,0 +1,8 @@
+# Override applied ON TOP of env/prod.yaml while this app runs on the
+# hub-utils-prod-us-east-1 cluster: only the ALB identity changes. Once the
+# migration is over, fold these keys into env/prod.yaml and delete this file.
+ingress:
+  annotations:
+    alb.ingress.kubernetes.io/load-balancer-name: "hub-utils-int-prod-cloudfront"
+    alb.ingress.kubernetes.io/group.name: "hub-utils-int-prod-cloudfront"
+    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub-utils,Terraform=true"


### PR DESCRIPTION
Wave 4 of the hub-utils migration (same parallel-deploy pattern as social-thumbnails / cloudimg / widgets-cors-proxy): minimal override layered on top of env/prod.yaml by the new Argo app — the ingress joins the existing shared hub-utils-int-prod-cloudfront ALB. Inert until the companion infra-deployments PR lands. Cutover is CloudFront-only (behavior target switch), no DNS handover.