### PR TITLE
chore: drop env/prod-v2.yaml (migration cleanup)

### DIFF
--- a/chart/env/prod-v2.yaml
+++ b/chart/env/prod-v2.yaml
@@ -1,8 +1,0 @@
-# Override applied ON TOP of env/prod.yaml while this app runs on the
-# hub-utils-prod-us-east-1 cluster: only the ALB identity changes. Once the
-# migration is over, fold these keys into env/prod.yaml and delete this file.
-ingress:
-  annotations:
-    alb.ingress.kubernetes.io/load-balancer-name: "hub-utils-int-prod-cloudfront"
-    alb.ingress.kubernetes.io/group.name: "hub-utils-int-prod-cloudfront"
-    alb.ingress.kubernetes.io/tags: "Env=prod,Project=hub-utils,Terraform=true"


### PR DESCRIPTION
Final migration cleanup: the renamed Argo app reads env/prod.yaml only (huggingface/infra-deployments#303), the hub-prod app is gone — this file is dead. No deploy risk.