### PR TITLE
Replay reasoning and tool calls in multi-turn history

### DIFF
--- a/src/messages.ts
+++ b/src/messages.ts
@@ -1,0 +1,160 @@
+import type {
+	ChatCompletionAssistantMessageParam,
+	ChatCompletionMessageParam,
+} from "openai/resources/chat/completions.js";
+import type { CreateResponseParams } from "./schemas.js";
+
+export type ChatMessage =
+	| Exclude<ChatCompletionMessageParam, { role: "assistant" }>
+	| (ChatCompletionAssistantMessageParam & { reasoning_content?: string });
+
+/*
+ * Convert Responses API input items to Chat Completion messages.
+ * Consecutive assistant items (reasoning, text, tool calls) are merged into one message.
+ */
+export function convertInputToMessages(
+	input: CreateResponseParams["input"],
+	instructions?: string | null
+): ChatMessage[] {
+	const messages: ChatMessage[] = instructions ? [{ role: "system", content: instructions }] : [];
+	if (Array.isArray(input)) {
+		const convertedMessages = input
+			.map((item) => {
+				switch (item.type) {
+					case "reasoning":
+						return {
+							role: "assistant" as const,
+							content: [],
+							reasoning_content: item.content.map((part) => part.text).join(""),
+						};
+					case "function_call":
+						return {
+							role: "assistant" as const,
+							content: [],
+							tool_calls: [
+								{
+									id: item.call_id,
+									type: "function" as const,
+									function: { name: item.name, arguments: item.arguments },
+								},
+							],
+						};
+					case "function_call_output":
+						return {
+							role: "tool" as const,
+							content: item.output,
+							tool_call_id: item.call_id,
+						};
+					case "message":
+					case undefined:
+						if (item.role === "assistant" || item.role === "user" || item.role === "system") {
+							const content =
+								typeof item.content === "string"
+									? item.content
+									: item.content
+											.map((content) => {
+												switch (content.type) {
+													case "input_image":
+														return {
+															type: "image_url" as const,
+															image_url: {
+																url: content.image_url,
+															},
+														};
+													case "output_text":
+														return content.text
+															? {
+																	type: "text" as const,
+																	text: content.text,
+																}
+															: undefined;
+													case "refusal":
+														return undefined;
+													case "input_text":
+														return {
+															type: "text" as const,
+															text: content.text,
+														};
+												}
+											})
+											.filter((item) => {
+												return item !== undefined;
+											});
+							return {
+								role: item.role,
+								content,
+							} as ChatCompletionMessageParam;
+						}
+						return undefined;
+					case "mcp_list_tools": {
+						return {
+							role: "tool" as const,
+							content: "MCP list tools. Server: '${item.server_label}'.",
+							tool_call_id: "mcp_list_tools",
+						};
+					}
+					case "mcp_call": {
+						return {
+							role: "tool" as const,
+							content: `MCP call (${item.id}). Server: '${item.server_label}'. Tool: '${item.name}'. Arguments: '${item.arguments}'.`,
+							tool_call_id: "mcp_call",
+						};
+					}
+					case "mcp_approval_request": {
+						return {
+							role: "tool" as const,
+							content: `MCP approval request (${item.id}). Server: '${item.server_label}'. Tool: '${item.name}'. Arguments: '${item.arguments}'.`,
+							tool_call_id: "mcp_approval_request",
+						};
+					}
+					case "mcp_approval_response": {
+						return {
+							role: "tool" as const,
+							content: `MCP approval response (${item.id}). Approved: ${item.approve}. Reason: ${item.reason}.`,
+							tool_call_id: "mcp_approval_response",
+						};
+					}
+				}
+			})
+			.filter(
+				(message): message is NonNullable<typeof message> =>
+					message !== undefined &&
+					("reasoning_content" in message ||
+						"tool_calls" in message ||
+						typeof message.content === "string" ||
+						(Array.isArray(message.content) && message.content.length !== 0))
+			);
+		for (const message of convertedMessages) {
+			const previous = messages.at(-1);
+			if (message.role === "assistant" && previous?.role === "assistant") {
+				previous.content = [
+					...(typeof previous.content === "string"
+						? [{ type: "text" as const, text: previous.content }]
+						: (previous.content ?? [])),
+					...(typeof message.content === "string"
+						? [{ type: "text" as const, text: message.content }]
+						: (message.content ?? [])),
+				];
+				if ("reasoning_content" in message)
+					previous.reasoning_content = (previous.reasoning_content ?? "") + message.reasoning_content;
+				if ("tool_calls" in message && message.tool_calls)
+					previous.tool_calls = [...(previous.tool_calls ?? []), ...message.tool_calls];
+			} else {
+				messages.push(message);
+			}
+		}
+	} else {
+		messages.push({ role: "user", content: input } as const);
+	}
+	for (const message of messages) {
+		if (!Array.isArray(message.content)) {
+			continue;
+		}
+		if (message.role === "assistant" && message.content.length === 0) {
+			delete message.content;
+		} else if (message.content.length === 1 && message.content[0].type === "text") {
+			message.content = message.content[0].text;
+		}
+	}
+	return messages;
+}

--- a/src/messages.ts
+++ b/src/messages.ts
@@ -21,12 +21,18 @@ export function convertInputToMessages(
 		const convertedMessages = input
 			.map((item) => {
 				switch (item.type) {
-					case "reasoning":
-						return {
-							role: "assistant" as const,
-							content: [],
-							reasoning_content: item.content.map((part) => part.text).join(""),
-						};
+					case "reasoning": {
+						// Prefer the verbatim reasoning, fall back to the summary when that is all the client replays.
+						const parts = item.content?.length ? item.content : (item.summary ?? []);
+						const reasoningContent = parts.map((part) => part.text).join("");
+						return reasoningContent
+							? {
+									role: "assistant" as const,
+									content: [],
+									reasoning_content: reasoningContent,
+								}
+							: undefined;
+					}
 					case "function_call":
 						return {
 							role: "assistant" as const,

--- a/src/routes/responses.ts
+++ b/src/routes/responses.ts
@@ -2,6 +2,7 @@ import { type Response as ExpressResponse } from "express";
 import { type ValidatedRequest } from "../middleware/validation.js";
 import type { CreateResponseParams, McpServerParams, McpApprovalRequestParams } from "../schemas.js";
 import { generateUniqueId } from "../lib/generateUniqueId.js";
+import { convertInputToMessages } from "../messages.js";
 import { OpenAI } from "openai";
 import type {
 	Response,
@@ -17,11 +18,7 @@ import type {
 	ReasoningTextContent,
 	PatchedDeltaWithReasoning,
 } from "../openai_patch";
-import type {
-	ChatCompletionCreateParamsStreaming,
-	ChatCompletionMessageParam,
-	ChatCompletionTool,
-} from "openai/resources/chat/completions.js";
+import type { ChatCompletionCreateParamsStreaming, ChatCompletionTool } from "openai/resources/chat/completions.js";
 import type { FunctionParameters } from "openai/resources/shared.js";
 import { callMcpTool, connectMcpServer } from "../mcp.js";
 
@@ -282,116 +279,7 @@ async function* innerRunStream(
 		tools = undefined;
 	}
 
-	// Prepare payload for the LLM
-
-	// Format input to Chat Completion format
-	const messages: ChatCompletionMessageParam[] = req.body.instructions
-		? [{ role: "system", content: req.body.instructions }]
-		: [];
-	if (Array.isArray(req.body.input)) {
-		messages.push(
-			...req.body.input
-				.map((item) => {
-					switch (item.type) {
-						case "function_call":
-							return {
-								role: "tool" as const,
-								content: item.arguments,
-								tool_call_id: item.call_id,
-							};
-						case "function_call_output":
-							return {
-								role: "tool" as const,
-								content: item.output,
-								tool_call_id: item.call_id,
-							};
-						case "message":
-						case undefined:
-							if (item.role === "assistant" || item.role === "user" || item.role === "system") {
-								const content =
-									typeof item.content === "string"
-										? item.content
-										: item.content
-												.map((content) => {
-													switch (content.type) {
-														case "input_image":
-															return {
-																type: "image_url" as const,
-																image_url: {
-																	url: content.image_url,
-																},
-															};
-														case "output_text":
-															return content.text
-																? {
-																		type: "text" as const,
-																		text: content.text,
-																	}
-																: undefined;
-														case "refusal":
-															return undefined;
-														case "input_text":
-															return {
-																type: "text" as const,
-																text: content.text,
-															};
-													}
-												})
-												.filter((item) => {
-													return item !== undefined;
-												});
-								const maybeFlatContent =
-									content.length === 1 &&
-									typeof content[0] === "object" &&
-									"type" in content[0] &&
-									content[0].type === "text"
-										? content[0].text
-										: content;
-								return {
-									role: item.role,
-									content: maybeFlatContent,
-								} as ChatCompletionMessageParam;
-							}
-							return undefined;
-						case "mcp_list_tools": {
-							return {
-								role: "tool" as const,
-								content: "MCP list tools. Server: '${item.server_label}'.",
-								tool_call_id: "mcp_list_tools",
-							};
-						}
-						case "mcp_call": {
-							return {
-								role: "tool" as const,
-								content: `MCP call (${item.id}). Server: '${item.server_label}'. Tool: '${item.name}'. Arguments: '${item.arguments}'.`,
-								tool_call_id: "mcp_call",
-							};
-						}
-						case "mcp_approval_request": {
-							return {
-								role: "tool" as const,
-								content: `MCP approval request (${item.id}). Server: '${item.server_label}'. Tool: '${item.name}'. Arguments: '${item.arguments}'.`,
-								tool_call_id: "mcp_approval_request",
-							};
-						}
-						case "mcp_approval_response": {
-							return {
-								role: "tool" as const,
-								content: `MCP approval response (${item.id}). Approved: ${item.approve}. Reason: ${item.reason}.`,
-								tool_call_id: "mcp_approval_response",
-							};
-						}
-					}
-				})
-				.filter(
-					(message): message is NonNullable<typeof message> =>
-						message !== undefined &&
-						(typeof message.content === "string" || (Array.isArray(message.content) && message.content.length !== 0))
-				)
-		);
-	} else {
-		messages.push({ role: "user", content: req.body.input } as const);
-	}
+	const messages = convertInputToMessages(req.body.input, req.body.instructions);
 
 	// Prepare payload for the LLM
 	const payload: ChatCompletionCreateParamsStreaming = {
@@ -607,7 +495,7 @@ async function* handleOneTurnStream(
 					// Response output item added event
 					yield {
 						type: "response.output_item.added",
-						output_index: 0,
+						output_index: responseObject.output.length - 1,
 						item: outputObject,
 						sequence_number: SEQUENCE_NUMBER_PLACEHOLDER,
 					};
@@ -626,7 +514,7 @@ async function* handleOneTurnStream(
 					// Response output item added event
 					yield {
 						type: "response.output_item.added",
-						output_index: 0,
+						output_index: responseObject.output.length - 1,
 						item: outputObject,
 						sequence_number: SEQUENCE_NUMBER_PLACEHOLDER,
 					};
@@ -704,13 +592,17 @@ async function* handleOneTurnStream(
 					sequence_number: SEQUENCE_NUMBER_PLACEHOLDER,
 				};
 			}
-		} else if (delta.tool_calls && delta.tool_calls.length > 0) {
+		}
+		if (delta.tool_calls && delta.tool_calls.length > 0) {
 			if (delta.tool_calls.length > 1) {
 				console.log("Multiple tool calls are not supported. Only the first one will be processed.");
 			}
 
 			let currentOutputItem = responseObject.output.at(-1);
 			if (delta.tool_calls[0].function?.name) {
+				if (currentOutputItem?.type === "message" || currentOutputItem?.type === "reasoning") {
+					for await (const event of closeLastOutputItem(responseObject, payload, mcpToolsMapping)) yield event;
+				}
 				const functionName = delta.tool_calls[0].function.name;
 				// Tool call with a name => new tool call
 				let newOutputObject:

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -116,8 +116,16 @@ export const createResponseParamsSchema = z.object({
 					type: z.literal("reasoning"),
 					id: z.string().optional(),
 					status: z.enum(["in_progress", "completed", "incomplete"]).optional(),
-					content: z.array(z.object({ type: z.literal("reasoning_text"), text: z.string() })),
-					summary: z.array(z.object({ type: z.literal("summary_text"), text: z.string() })).optional(),
+					// Both are optional: the Responses API returns `content` for verbatim reasoning and
+					// `summary` when the reasoning is summarized. Clients replay whichever they received.
+					content: z
+						.array(z.object({ type: z.literal("reasoning_text"), text: z.string() }))
+						.optional()
+						.default([]),
+					summary: z
+						.array(z.object({ type: z.literal("summary_text"), text: z.string() }))
+						.optional()
+						.default([]),
 				}),
 				z.object({
 					type: z.literal("function_call"),

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -113,6 +113,13 @@ export const createResponseParamsSchema = z.object({
 					),
 				}),
 				z.object({
+					type: z.literal("reasoning"),
+					id: z.string().optional(),
+					status: z.enum(["in_progress", "completed", "incomplete"]).optional(),
+					content: z.array(z.object({ type: z.literal("reasoning_text"), text: z.string() })),
+					summary: z.array(z.object({ type: z.literal("summary_text"), text: z.string() })).optional(),
+				}),
+				z.object({
 					type: z.literal("function_call"),
 					id: z.string().optional(),
 					call_id: z.string(),

--- a/tests/tool-history.test.js
+++ b/tests/tool-history.test.js
@@ -1,0 +1,25 @@
+import { strict as assert } from "assert";
+import { convertInputToMessages } from "../dist/messages.js";
+
+describe("tool history", function () {
+	it("replays reasoning and the tool call as one assistant message", function () {
+		const messages = convertInputToMessages([
+			{ role: "user", content: "Read the file." },
+			{ type: "reasoning", content: [{ type: "reasoning_text", text: "I should read the file first." }] },
+			{ type: "function_call", call_id: "call_1", name: "read_file", arguments: '{"path":"README.md"}' },
+			{ type: "function_call_output", call_id: "call_1", output: "file contents" },
+		]);
+
+		assert.deepEqual(messages, [
+			{ role: "user", content: "Read the file." },
+			{
+				role: "assistant",
+				reasoning_content: "I should read the file first.",
+				tool_calls: [
+					{ id: "call_1", type: "function", function: { name: "read_file", arguments: '{"path":"README.md"}' } },
+				],
+			},
+			{ role: "tool", content: "file contents", tool_call_id: "call_1" },
+		]);
+	});
+});

--- a/tests/tool-history.test.js
+++ b/tests/tool-history.test.js
@@ -1,5 +1,6 @@
 import { strict as assert } from "assert";
 import { convertInputToMessages } from "../dist/messages.js";
+import { createResponseParamsSchema } from "../dist/schemas.js";
 
 describe("tool history", function () {
 	it("replays reasoning and the tool call as one assistant message", function () {
@@ -20,6 +21,66 @@ describe("tool history", function () {
 				],
 			},
 			{ role: "tool", content: "file contents", tool_call_id: "call_1" },
+		]);
+	});
+
+	it("merges parallel tool calls into a single assistant message", function () {
+		const messages = convertInputToMessages([
+			{ role: "user", content: "Read both files." },
+			{ type: "reasoning", content: [{ type: "reasoning_text", text: "Read them in parallel." }] },
+			{ type: "function_call", call_id: "call_1", name: "read_file", arguments: '{"path":"a"}' },
+			{ type: "function_call", call_id: "call_2", name: "read_file", arguments: '{"path":"b"}' },
+			{ type: "function_call_output", call_id: "call_1", output: "a contents" },
+			{ type: "function_call_output", call_id: "call_2", output: "b contents" },
+		]);
+
+		assert.deepEqual(messages, [
+			{ role: "user", content: "Read both files." },
+			{
+				role: "assistant",
+				reasoning_content: "Read them in parallel.",
+				tool_calls: [
+					{ id: "call_1", type: "function", function: { name: "read_file", arguments: '{"path":"a"}' } },
+					{ id: "call_2", type: "function", function: { name: "read_file", arguments: '{"path":"b"}' } },
+				],
+			},
+			{ role: "tool", content: "a contents", tool_call_id: "call_1" },
+			{ role: "tool", content: "b contents", tool_call_id: "call_2" },
+		]);
+	});
+
+	it("accepts summary-only reasoning items and replays the summary", function () {
+		// The Responses API returns `summary` instead of `content` when reasoning is summarized,
+		// so neither field can be required.
+		const parsed = createResponseParamsSchema.parse({
+			model: "some-model",
+			input: [
+				{ role: "user", content: "Read the file." },
+				{ type: "reasoning", id: "rs_1", summary: [{ type: "summary_text", text: "Reading the file." }] },
+				{ type: "function_call", call_id: "call_1", name: "read_file", arguments: "{}" },
+			],
+		});
+
+		assert.deepEqual(convertInputToMessages(parsed.input), [
+			{ role: "user", content: "Read the file." },
+			{
+				role: "assistant",
+				reasoning_content: "Reading the file.",
+				tool_calls: [{ id: "call_1", type: "function", function: { name: "read_file", arguments: "{}" } }],
+			},
+		]);
+	});
+
+	it("drops reasoning items that carry no text", function () {
+		const messages = convertInputToMessages([
+			{ role: "user", content: "Hi." },
+			{ type: "reasoning", id: "rs_1", content: [], summary: [] },
+			{ type: "message", role: "assistant", content: [{ type: "output_text", text: "Hello!" }] },
+		]);
+
+		assert.deepEqual(messages, [
+			{ role: "user", content: "Hi." },
+			{ role: "assistant", content: "Hello!" },
 		]);
 	});
 });


### PR DESCRIPTION
I hit this while setting up Codex with DeepSeek V4.1 Flash via HF/Novita: the tool loop failed on continuation. This completes reasoning items before function calls, replays their text, and pairs assistant function calls with their results.

Related fixes:

- [LiteLLM: preserve reasoning input items and signed thinking blocks](https://github.com/BerriAI/litellm/pull/36355) — merges replayed reasoning into the next assistant message. [Implementation](https://github.com/BerriAI/litellm/blob/fbed17d567a62b14b8fc7d9ef13c5cd61a8d1ae0/litellm/responses/litellm_completion_transformation/transformation.py#L668-L695).
- [Vercel AI SDK: include reasoning in assistant messages for multi-turn tool calls](https://github.com/vercel/ai/pull/12049) — fixes missing reasoning during Kimi tool calls. [Implementation](https://github.com/vercel/ai/blob/7469a3bc5daf0fd8c535c903f883d730a39de191/packages/openai-compatible/src/chat/convert-to-openai-compatible-chat-messages.ts#L239-L245).

## Observed provider results

Pi → local Responses.js → Hugging Face router. A pass means two completed tool calls, correct file contents, and final confirmation.

| Model | Provider | Before | After |
| --- | --- | --- | --- |
| DeepSeek V4.1 Flash | Novita | ❌ 400 on continuation | ✅ Pass |
| Kimi-K2.6 | Novita | ❌ 400 after first tool | ✅ Pass |
| Kimi-K2.6 | DeepInfra | ⚠️ Incomplete: tools run, no final confirmation | ✅ Pass |
| GPT-OSS-120B | Fireworks | ❌ 400: missing matching assistant tool call | ✅ Pass |
| GPT-OSS-120B | Groq | ❌ 400: tool-history formatting error | ❌ 400: rejects `reasoning_content` |

## Baseten: the task passes, but reasoning is lost

Kimi-K2.6 via HF/Baseten completed the task with both adapters. Capturing both sides showed that only the patched adapter replayed the original reasoning and correctly paired each tool call with its result.

## Before: reasoning is lost between requests

The adapter never finishes the reasoning item before the tool call, so Pi does not save it for replay. The HF/Baseten route still completes the task despite receiving no prior reasoning and two tool-result messages instead of a call/result pair.

```mermaid
sequenceDiagram
    participant H as HF / Baseten
    participant R as Responses.js
    participant P as Pi
    H->>R: Reasoning deltas
    R->>P: Reasoning starts + text deltas
    H->>R: Tool call
    R->>P: Tool call
    Note over R,P: No reasoning output_item.done
    P->>P: Run tool
    P->>R: Call + result, no reasoning
    R->>H: Two tool results, no assistant call or reasoning
    H->>R: Continues despite malformed history
    R->>P: Task completes
```

## After: reasoning survives the tool loop

The adapter finishes the reasoning item, allowing Pi to save and replay it alongside the tool call and result. Both tool turns sent back the exact original reasoning, with each tool result matched to its call.

```mermaid
sequenceDiagram
    participant H as HF / Baseten
    participant R as Responses.js
    participant P as Pi
    H->>R: Reasoning deltas
    R->>P: Reasoning starts + text deltas
    H->>R: Tool call
    R->>P: Complete reasoning item
    P->>P: Save reasoning for replay
    R->>P: Tool call
    P->>P: Run tool
    P->>R: Reasoning + call + result
    R->>H: Assistant reasoning + tool call, then tool result
    H->>R: Continues
    R->>P: Task completes
```
